### PR TITLE
updated index for cleanup

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -151,10 +151,10 @@
                                     <p>pip install -U trinity</p>
                                 </div>    
                                 <h6>Paste that at a Terminal prompt.</h6>
-                                <p>For detailed installation instruction go to: </br><a href="https://trinity-client.readthedocs.io/en/latest/guides/quickstart.html#installation">https://trinity-client.readthedocs.io/en/latest/guides/quickstart.html#installation</a></p>
-                                <p>Quick Start: <a href="https://trinity-client.readthedocs.io/en/latest/guides/quickstart.html">https://trinity-client.readthedocs.io/en/latest/guides/quickstart.html</a></p>
-                                <p>Github: <a href="https://github.com/ethereum/trinity">https://github.com/ethereum/trinity</a></p>
-                                <p>Serenity (Eth 2.0) Beacon Chain implementation: <a href="https://github.com/ethereum/trinity/blob/master/eth2/README.md">https://github.com/ethereum/trinity/blob/master/eth2/README.md</a></p>
+                                <p><a href="https://trinity-client.readthedocs.io/en/latest/guides/quickstart.html#installation">Detailed Instructions</a></p>
+                                <p><a href="https://trinity-client.readthedocs.io/en/latest/guides/quickstart.html">Quick Start Guide</a></p>
+                                <h4>Additional Resources</h4>
+                                <p><a href="https://github.com/ethereum/trinity/blob/master/eth2/README.md">Serenity (Eth 2.0) Beacon Chain implementation</a></p>
                             </div>
                         </div>
                         <div class="col-md-6 col-lg-4 col-12 text-center"> <img class="triceratops" alt="Triceratops" src="images/triceratops@2x.png"> </div>


### PR DESCRIPTION
Have descriptions then long links felt clunky. This cleans up so the text iself are links. Also separates the install section from extra resources.

I suggest removing the github link as well since it's on the top and bottom of the page. Seemed redundant.